### PR TITLE
fixed a typo ohwa-s02e10.md

### DIFF
--- a/office-hours-with-arbitrage/office-hours-recaps-season-2/ohwa-s02e10.md
+++ b/office-hours-with-arbitrage/office-hours-recaps-season-2/ohwa-s02e10.md
@@ -12,7 +12,7 @@ The full interview with Suraj will be published on YouTube.
 
 ### Questions from Slido
 
-**Which one is less wrong: `import torch stf` or `import tensorFlow as torch`?**
+**Which one is less wrong: `import torch as tf` or `import tensorflow as torch`?**
 
 Resident neural net wizard [JRB](https://numer.ai/jrb) said both are pretty much equally wrong, a more optimal method would be `import jax.numpy as np`. 
 


### PR DESCRIPTION
A small change in syntax for importing `torch` and `tensorflow`