### PR TITLE
Add a link to Japanese documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 # Table of contents
 
 * [Numerai Tournament Docs](README.md)
+* [Japanese/日本語](https://jp.docs.numer.ai/)
 
 ## Tournament
 


### PR DESCRIPTION
Add a link to https://jp.docs.numer.ai/
