### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import pandas as pd
 
 napi = NumerAPI()
 napi.download_dataset("v5.0/train.parquet")
-training_data = pd.read_parquet("v5.0/tra.parquet")
+training_data = pd.read_parquet("v5.0/train.parquet")
 ```
 
 See the [Data](numerai-tournament/data.md) section for more details.&#x20;


### PR DESCRIPTION
### Issue

Typo in readme causes error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'v5.0/tra.parquet'
```

I verified that the error is no longer throw after the fix.