### PR TITLE
[codex] Update V3 staking docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -18,6 +18,7 @@
   * [True Contribution (TC)](numerai-tournament/scoring/true-contribution-tc.md)
   * [Grandmasters & Seasons](numerai-tournament/scoring/grandmasters-and-seasons.md)
 * [Staking](numerai-tournament/staking.md)
+* [Atomic Blockchain Staking](numerai-tournament/atomic-blockchain-staking.md)
 * [MCP](numerai-tournament/mcp.md)
 * [Bounties](numerai-tournament/bounties.md)
 

--- a/numerai-crypto/staking.md
+++ b/numerai-crypto/staking.md
@@ -4,7 +4,9 @@ description: How to earn (or burn) with your Crypto model.
 
 # Staking
 
-If your signal has sufficiently low [churn and turnover](../numerai-signals/scoring/#what-is-churn-and-turnover), you may optionally `stake` [NMR](https://www.coinbase.com/price/numeraire) on your model to earn or burn based on your scores. Staking means locking up your NMR and giving Numerai permission to add payouts to or burn from the NMR locked up. For general rules about staking and payouts, please read the [main staking documentation](../numerai-tournament/staking.md).
+You may optionally `stake` [NMR](https://www.coinbase.com/price/numeraire) on your model to earn or burn based on your scores. Staking means locking up your NMR during the scoring period and giving Numerai permission to add payouts to or burn from the NMR at stake.
+
+Use the [Atomic Blockchain Staking documentation](../numerai-tournament/atomic-blockchain-staking.md) for the current staking flow, including the Privy embedded wallet, allocation strategy setup, strategy deposits and withdrawals, per-model stake settings, Compound mode, Fixed mode, and API automation.
 
 {% hint style="info" %}
 It is important to note that the opportunity to stake your signal is not an offer by Numerai to participate in an investment contract, a security, a swap based on the return of any financial assets, an interest in Numerai’s hedge fund, or in Numerai itself or any fees we earn. Payouts will be made at our discretion, based on a blackbox target that will not be disclosed to users. Fundamentally, Numerai Signals is a service offered by Numerai that allows users to assess the value of their signals, using NMR staking as a way to validate “real” signals. In return, Numerai uses the staked signals and related data in the Numerai hedge fund. Users with different expectations should not stake signals.
@@ -14,10 +16,10 @@ It is important to note that the opportunity to stake your signal is not an offe
 
 ## Payouts
 
-Payouts are a function of your stake value and scores. Please review the [main staking documentation](../numerai-tournament/staking.md) to understand how payouts work generally. The Signals payout function is specifically:
+Payouts are a function of your stake value and scores. Please review the [main staking documentation](../numerai-tournament/staking.md) to understand how payouts work generally. The legacy continuous staking Crypto payout function is:
 
 ```python
-payout = stake * clip(payout_factor * mmc), -0.05, 0.05)
+payout = stake * clip(payout_factor * mmc, -0.05, 0.05)
 ```
 
-The `payout_factor` reduces logarithmically as the total NMR staked grows over the `stake_cap_threshold.`See the values of `stake_cap_threshold` [here](../numerai-tournament/staking.md#the-payout-factor).
+See the [main staking documentation](../numerai-tournament/staking.md#the-payout-factor) for legacy payout factor details and stake threshold values. See [Atomic Blockchain Staking](../numerai-tournament/atomic-blockchain-staking.md#claims-and-payouts) for the current atomic staking claim and payout flow.

--- a/numerai-signals/staking.md
+++ b/numerai-signals/staking.md
@@ -4,7 +4,9 @@ description: How to earn (or burn) NMR with your Signals model
 
 # Staking
 
-If your signal has sufficiently low [churn and turnover](scoring/#what-is-churn-and-turnover), you may optionally `stake` [NMR](https://www.coinbase.com/price/numeraire) on your model to earn or burn based on your scores. Staking means locking up your NMR and giving Numerai permission to add payouts to or burn from the NMR locked up. For general rules about staking and payouts, please read the [main staking documentation](../numerai-tournament/staking.md).
+If your signal has sufficiently low [churn and turnover](scoring/#what-is-churn-and-turnover), you may optionally `stake` [NMR](https://www.coinbase.com/price/numeraire) on your model to earn or burn based on your scores. Staking means locking up your NMR during the scoring period and giving Numerai permission to add payouts to or burn from the NMR at stake.
+
+Use the [Atomic Blockchain Staking documentation](../numerai-tournament/atomic-blockchain-staking.md) for the current staking flow, including the Privy embedded wallet, allocation strategy setup, strategy deposits and withdrawals, per-model stake settings, Compound mode, Fixed mode, and API automation.
 
 {% hint style="info" %}
 It is important to note that the opportunity to stake your signal is not an offer by Numerai to participate in an investment contract, a security, a swap based on the return of any financial assets, an interest in Numerai’s hedge fund, or in Numerai itself or any fees we earn. Payouts will be made at our discretion, based on a blackbox target that will not be disclosed to users. Fundamentally, Numerai Signals is a service offered by Numerai that allows users to assess the value of their signals, using NMR staking as a way to validate “real” signals. In return, Numerai uses the staked signals and related data in the Numerai hedge fund. Users with different expectations should not stake signals.
@@ -14,16 +16,12 @@ It is important to note that the opportunity to stake your signal is not an offe
 
 ## Payouts
 
-Payouts are a function of your stake value and scores. Please review the [main staking documentation](../numerai-tournament/staking.md) to understand how payouts work generally. The Signals payout function is specifically:
+Payouts are a function of your stake value and scores. Please review the [main staking documentation](../numerai-tournament/staking.md) to understand how payouts work generally.
 
-```python
-payout = stake * clip(payout_factor * (fncv4 * 1 + mmc * 2), -0.05, 0.05)  
-```
-
-For rounds starting on September 2nd, 2025, the payout function will change to:
+The legacy continuous staking Signals payout function is:
 
 ```python
 payout = stake * clip(payout_factor * (alpha * 0.3 + mpc * 0.8), -0.017, 0.017)  
 ```
 
-The `payout_factor` reduces logarithmically as the total NMR staked grows over the `stake_cap_threshold.`See the values of `stake_cap_threshold` [here](../numerai-tournament/staking.md#the-payout-factor).
+See the [main staking documentation](../numerai-tournament/staking.md#the-payout-factor) for legacy payout factor details and stake threshold values. See [Atomic Blockchain Staking](../numerai-tournament/atomic-blockchain-staking.md#claims-and-payouts) for the current atomic staking claim and payout flow.

--- a/numerai-tournament/atomic-blockchain-staking.md
+++ b/numerai-tournament/atomic-blockchain-staking.md
@@ -1,0 +1,77 @@
+# Atomic Blockchain Staking
+
+Atomic Blockchain Staking is Numerai's current blockchain-native staking system. It is also referred to as staking v3 in API and contract names. It locks NMR atomically per round, tracks each model's stake independently, and lets resolved stakes be claimed when a round resolves.
+
+You can interact with Atomic Blockchain Staking manually through the contracts and API, or automate staking with an account allocation strategy. Most users should use the Dashboard > **V3 Stakes** page, which manages the Privy embedded wallet and allocation strategy flow.
+
+## Staking Flow
+
+Atomic Blockchain Staking is managed from your Dashboard:
+
+1. Go to [Dashboard](https://numer.ai/dashboard) > **V3 Stakes**.
+2. Use the Privy embedded wallet shown on the page. This wallet is the account wallet used for atomic staking actions.
+3. Enable your account allocation strategy. The allocation strategy is a user-owned smart contract that holds your staking policy and idle strategy NMR.
+4. Deposit NMR from your Privy embedded wallet into the allocation strategy.
+5. Configure each model's per-round stake and payout mode.
+6. Save the model settings.
+7. Monitor **Stake Activity** and **Wallet Activity** on the V3 Stakes page.
+
+Numerai's staking operator invokes your allocation strategy according to your saved per-model settings. You are not required to interact with the blockchain directly when you use the allocation strategy flow.
+
+## Per-Round Stake Settings
+
+Each model has a per-round stake setting. This is the NMR amount the allocation strategy will try to stake for that model when a new eligible round opens.
+
+Atomic Blockchain Staking supports two automated modes:
+
+* **Compound**: rolls resolved releasable value forward above your configured per-round stake. Your configured per-round stake acts as the minimum.
+* **Fixed**: stakes the configured per-round amount and leaves extra resolved value idle in the allocation strategy. This is the website label for the constant, or take-profit, strategy mode.
+
+In either mode, the allocation strategy can only stake according to the model settings you save.
+
+## Claims and Payouts
+
+When a round resolves, Numerai generates model-scoped stake claims based on the final payout and burn values, then posts a Merkle root on-chain so the staking contract can verify claims.
+
+Atomic Blockchain Staking removes continuous-stake overlap leverage and the legacy per-round clip. Payouts and burns are applied to the NMR staked for each model and round. If you use stake automation, resolved stakes can be claimed and restaked in one transaction; burns can be netted against future same-model payouts while you continue staking.
+
+## Reducing Stake
+
+To reduce future exposure, lower the model's per-round stake and withdraw any idle strategy NMR back to your Privy embedded wallet. NMR already staked in an active round remains locked until that round settles.
+
+The legacy V2 stake release process does not apply to Atomic Blockchain Staking.
+
+## Migration
+
+The legacy off-chain continuous staking system is being replaced by Atomic Blockchain Staking. Once a tournament is migrated, legacy continuous staking pages and API mutations for increasing or decreasing stake are no longer used for that tournament.
+
+During migration, Numerai handles provisioning Privy embedded wallets and allocation strategies, then migrates staked NMR from the Numerai Wallet into allocation strategies and staking contracts over the tournament's overlap period.
+
+The announced migration schedule is:
+
+| Tournament | Migration starts | Expected migration length |
+| ---------- | ---------------- | ------------------------- |
+| Crypto     | June 16, 2026    | 24 business days          |
+| Signals    | June 23, 2026    | 64 business days          |
+| Numerai    | June 23, 2026    | 24 business days          |
+
+The Numerai Wallet remains accessible for wallet history and non-staking transfers, but it is no longer the place to manage new stakes after a tournament migrates.
+
+## API and Automation
+
+API tokens that automate Atomic Blockchain Staking need the `web3_staking` scope.
+
+The staking v3 API fields are intended for contract-aware automation:
+
+* `v3StakeConfig` returns staking contract metadata for a tournament.
+* `v3StakeRound` returns round status and round-level staking parameters.
+* `v3StakeAuth` issues a staking authorization for an eligible selected submission.
+* `v3StakeClaim` returns the claim proof for an authenticated model and staker after a round resolves.
+
+At a high level, stake authorizations are tied to selected submissions while staking is open, and claims are model-scoped. If you automate beyond the website flow, keep your scripts aligned with the allocation strategy settings you own.
+
+Once a tournament's Atomic Blockchain Staking flag is enabled, the legacy V2 staking mutations for that tournament are disabled. Use the Atomic Blockchain Staking flow and staking v3 API fields instead.
+
+## Withdrawing NMR
+
+When you are ready to withdraw idle NMR, first withdraw it from the allocation strategy to your Privy embedded wallet from the V3 Stakes page. You can then use the embedded wallet controls to send NMR to an external Ethereum address. Active round stake remains locked until settlement.

--- a/numerai-tournament/staking.md
+++ b/numerai-tournament/staking.md
@@ -22,44 +22,36 @@ NMR is the cryptocurrency that powers staking and payouts on Numerai.
 * You can read more about NMR on Github: [https://github.com/erasureprotocol/NMR](https://github.com/erasureprotocol/NMR)
 * You can see token statistics here: [https://numer.ai/nmr](https://numer.ai/nmr)
 
-To stake NMR on your model you must first acquire NMR, then deposit it into your [Numerai wallet](https://numer.ai/wallet). When you are ready, you can withdraw it to a given eth address.
+To stake NMR on your model you must first acquire NMR, then use the [Atomic Blockchain Staking](atomic-blockchain-staking.md) flow to fund your Privy embedded wallet, enable your allocation strategy, and configure per-model stake settings.
 
-## Depositing NMR
+## Getting NMR
 
 We recommend two places for buying NMR&#x20;
 
 * [Coinbase](https://www.coinbase.com/price/numeraire) - a safe and easy place to buy NMR with USD, GBP, EUR or Bitcoin. A good place to start if you are new to crypto. Availability depends on your region.
 * [Uniswap](https://app.uniswap.org/#/swap?outputCurrency=0x1776e1f26f98b1a5df9cd347953a26dd3cb46671) - a decentralized exchange you can use to swap Ethereum based tokens like ETH or USDC for NMR. Requires you to bring your own wallet like MetaMask. Great for DeFi enthusiasts.
 
-Once you own NMR, use the [Wallet](https://numer.ai/wallet) address to send NMR to your Numerai Wallet:
+Once you own NMR, send it to the Privy embedded wallet address shown on the [V3 Stakes](https://numer.ai/dashboard/v3-stakes) page.
 
-<figure><img src="../.gitbook/assets/image (15).png" alt=""><figcaption><p>numer.ai/wallet</p></figcaption></figure>
+## Atomic Blockchain Staking
 
-### Restrictions
+Current staking setup and stake management are handled through the standalone [Atomic Blockchain Staking](atomic-blockchain-staking.md) flow. Use that page for:
 
-To prevent fraud and money laundering, we place withdrawal restrictions on new accounts. In order to withdraw from your Numerai Wallet, your account must either be 30 days old or you must withdraw more than 0.1 NMR. This means if you just created your account and deposit 0.1 NMR, you cannot withdraw this amount until either your account reaches 30 days of age or you deposit more NMR first.
+* enabling and funding your allocation strategy.
+* configuring each model's per-round stake.
+* choosing Compound or Fixed mode.
+* understanding atomic per-round locks, claims, and migration.
+* reducing future stake exposure.
+* withdrawing idle strategy NMR.
+* using the staking v3 API fields for automation.
 
-## Increasing Stake
+## Legacy Continuous Staking Payouts
 
-Head over to [numer.ai/staking](https://numer.ai/staking), and click on the "manage stake" button next to the model on which you would like to stake:&#x20;
+Your payout is primarily a function of your scores. If you have a positive score you will get a payout. If you have a negative score a portion of your stake will burn.
 
-<figure><img src="../.gitbook/assets/Screenshot 2024-03-22 at 1.56.52 PM.png" alt=""><figcaption><p>If you're on a smaller screen, you may need to scroll to find this button.</p></figcaption></figure>
+The formula below describes the legacy continuous staking payout function. Atomic Blockchain Staking removes continuous-stake overlap leverage and the legacy per-round clip; see [Atomic Blockchain Staking](atomic-blockchain-staking.md#claims-and-payouts).
 
-This will open the Stake Modal. You can use this to stake NMR from your wallet on your model:
-
-<div align="center"><figure><img src="../.gitbook/assets/image (107).png" alt=""><figcaption></figcaption></figure></div>
-
-## Releasing Stake
-
-Staked NMR will remain locked until you release it back to your wallet, which takes 1 month. Specifically, the NMR will be released at the resolution of your last active round at the time of the request. While pending release, the unstaked amount may still be subject to burns but will not count towards upcoming payouts.
-
-<figure><img src="../.gitbook/assets/image (36).png" alt=""><figcaption></figcaption></figure>
-
-## Payouts
-
-Your payout is a primarily a function of your scores. If you have a positive score you will get a payout. If you have a negative score a portion of your stake will burn.
-
-The maximum payout or burn per round is capped at ±5% and uses the following formula:
+The maximum payout or burn per round is capped at +/-5% and uses the following formula:
 
 ```
 score = corr20 * corr_multiplier + mmc20 * mmc_multiplier
@@ -67,7 +59,7 @@ payout = stake * clip(payout_factor * (score), -0.05, 0.05)
 ```
 
 * `corr20` and `mmc20` are the 20-day [CORR](scoring/correlation-corr.md) and [MMC](scoring/meta-model-contribution-mmc.md) scores respectively. These are multiplied by their relevant multipliers, which don't change often and can be checked on a round-by-round basis (see the latest round [here](https://numer.ai/round/latest)).
-* `stake` is your model's stake value at the `close` of the round. This is also referred to as the stake value `at-risk` for a round. Your stake value `at-risk` for a round does not include any unstaked amounts that are pending release, and is set to 0 if you have no valid submission for a round.
+* `stake` is your model's stake value at the `close` of the round. This is also referred to as the stake value `at-risk` for a round. Your stake value `at-risk` for a round does not include idle strategy NMR, and is set to 0 if you have no valid submission for a round.
 
 #### The Payout Factor
 
@@ -89,11 +81,7 @@ Here is an example of what the Numerai payout factor looks as stake grows:
 
 ## Withdrawing NMR
 
-When you are ready to withdraw NMR from your Numerai Wallet visit the [Wallet Page](https://numer.ai/wallet), specify an amount, and copy your destination address into the relevant text box:
-
-<figure><img src="../.gitbook/assets/Screenshot 2024-03-13 at 4.42.37 PM.png" alt="" width="375"><figcaption></figcaption></figure>
-
-Finally, click "Next" and wait for the page to show a confirmation. It may take a few moments to complete the transaction, so please be patient.
+For Atomic Blockchain Staking, see [Withdrawing NMR](atomic-blockchain-staking.md#withdrawing-nmr). Active round stake remains locked until settlement.
 
 ## Tax Reporting
 


### PR DESCRIPTION
## Summary
- add `numerai-tournament/atomic-blockchain-staking.md` as a standalone public Atomic Blockchain Staking page parallel to the general staking page
- keep `numerai-tournament/staking.md` focused on general staking, NMR acquisition, and legacy continuous-staking payout context
- update Signals and Crypto staking pages to point directly to Atomic Blockchain Staking for setup, funding, modes, withdrawals, and automation
- add a concise staking v3 API automation section covering `web3_staking`, `v3StakeConfig`, `v3StakeRound`, `v3StakeAuth`, and `v3StakeClaim`

## Announcement alignment report
Source: https://forum.numer.ai/t/what-is-atomic-blockchain-staking/8302

Aligned in this PR:
- public naming is now `Atomic Blockchain Staking`, with staking v3 kept only for API/contract terminology
- the standalone page describes atomic per-round locks, model-scoped claims, manual/automated staking, allocation strategies, Privy wallet setup, migration from continuous staking, and the announced migration schedule
- general/Signals/Crypto clipped payout formulas are now explicitly labeled as legacy continuous-staking context
- the Atomic Blockchain Staking page states that continuous-stake overlap leverage and the legacy per-round clip are removed
- the Numerai Wallet is described as no longer the place to manage new stakes after migration

Open product/docs mismatch to resolve separately:
- the forum FAQ says the ABS release equivalent is setting per-round stake to 0, but the current V3 Stakes UI code still validates per-round stake as greater than 0, so this PR documents reducing future exposure by lowering per-round stake and withdrawing idle strategy NMR rather than documenting a zero-stake control that is not currently exposed.

## Coordination
- Internal source-of-truth PR: https://github.com/numerai/monorepo-tournament/pull/460
- This PR is the public-facing documentation update; the monorepo PR records the internal source-of-truth wording.

## Validation
- `git diff --check`
- manually reviewed links in the `SUMMARY.md`-reachable staking pages edited here, including the new Atomic Blockchain Staking page
- scanned edited staking pages for stale v2 staking flow language (`1 month`, `Stake Modal`, `numer.ai/staking`, `Numerai Wallet`, pending release wording)
- checked current monorepo UI/API names for the dashboard `V3 Stakes` tab, Privy wallet, allocation strategy funding, Compound/Fixed modes, activity tables, `web3_staking`, and v3 GraphQL fields